### PR TITLE
fix: removed need for deprecated `ugettext_lazy`

### DIFF
--- a/django_bitmask_field.py
+++ b/django_bitmask_field.py
@@ -5,7 +5,7 @@ from django import forms
 from django.core import checks, exceptions, validators
 from django.db import models
 from django.utils.encoding import force_bytes
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from six import integer_types, text_type, PY3
 from six.moves import reduce
 


### PR DESCRIPTION
`ugettext_lazy` is removed in Django 4, because unicode is default by now.

https://docs.djangoproject.com/en/4.2/releases/4.0/#features-removed-in-4-0